### PR TITLE
README siteentry: Update Travis badge for new repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Version 0.8.0
 
-[![Travis CI results](https://travis-ci.org/cshoredaniel/hugo-oldnew-mashup.svg?branch=master)](https://travis-ci.org/cshoredaniel/hugo-oldnew-mashup?branch=master)
+[![Travis CI results](https://travis-ci.org/cshoredaniel/new-oldnew-mashup.svg?branch=master)](https://travis-ci.org/cshoredaniel/new-oldnew-mashup?branch=master)
 
 ## Overview
 

--- a/exampleSite/content/siteentry/_index.md
+++ b/exampleSite/content/siteentry/_index.md
@@ -10,7 +10,7 @@ layout: siteentry
 
 Version 0.8.0
 
-[![Travis CI results](https://travis-ci.org/cshoredaniel/hugo-oldnew-mashup.svg?branch=master)](https://travis-ci.org/cshoredaniel/hugo-oldnew-mashup?branch=master)
+[![Travis CI results](https://travis-ci.org/cshoredaniel/new-oldnew-mashup.svg?branch=master)](https://travis-ci.org/cshoredaniel/new-oldnew-mashup?branch=master)
 
 ## Overview
 


### PR DESCRIPTION
We've moved the new version of the theme to separate repository, so we need to update
the Travis badge.  This does that.

Signed-off-by: Daniel F. Dickinson <cshored@thecshore.com>