### PR TITLE
Prevent showing more than two levels in menubar

### DIFF
--- a/exampleSite/content/Viverra Justo/Mangi Dolores/Quia Non Numquam/Mauris/Facto.md
+++ b/exampleSite/content/Viverra Justo/Mangi Dolores/Quia Non Numquam/Mauris/Facto.md
@@ -1,0 +1,11 @@
+---
+title: "Facto"
+date: 2019-09-22T17:13:45-04:00
+copyright: 2019 Daniel F. Dickinson
+author: Daniel F. Dickinson <cshored@thecshore.com>
+description:
+licenses:
+  - CC-BY-4.0
+categories:
+tags:
+---

--- a/exampleSite/content/Viverra Justo/Mangi Dolores/Quia Non Numquam/Mauris/_index.md
+++ b/exampleSite/content/Viverra Justo/Mangi Dolores/Quia Non Numquam/Mauris/_index.md
@@ -1,0 +1,11 @@
+---
+title: "Mauris"
+date: 2019-09-22T17:13:36-04:00
+copyright: 2019 Daniel F. Dickinson
+author: Daniel F. Dickinson <cshored@thecshore.com>
+description:
+licenses:
+  - CC-BY-4.0
+categories:
+tags:
+---

--- a/exampleSite/resources/_gen/assets/scss/css/oldnew-mashup.scss_edfe92e93c605395fc6c399f82aa3ba0.content
+++ b/exampleSite/resources/_gen/assets/scss/css/oldnew-mashup.scss_edfe92e93c605395fc6c399f82aa3ba0.content
@@ -1331,6 +1331,10 @@ table {
     flex-flow: row nowrap;
     justify-content: stretch;
     margin-left: 2em; }
+    .menubar-site-menu .menu-parent .menu-item .menu-parent:nth-child(1n+2) {
+      display: none; }
+      .menubar-site-menu .menu-parent .menu-item .menu-parent:nth-child(1n+2) .menu-item {
+        display: none; }
     .menubar-site-menu > .menubar-site-menu-list {
       align-content: space-around;
       align-items: center;

--- a/layouts/partials/scss/real-scss/menubar.scss
+++ b/layouts/partials/scss/real-scss/menubar.scss
@@ -388,6 +388,21 @@
     justify-content: stretch;
     margin-left: 2em;
 
+    .menu-parent {
+      // sass-lint:disable nesting-depth
+      & .menu-item {
+        & .menu-parent {
+          &:nth-child(1n+2) {
+            display: none;
+
+            & .menu-item {
+              display: none;
+            }
+          }
+        }
+      }
+    }
+
     & > .menubar-site-menu-list {
       @include large-screen-menu-item-search;
 

--- a/resources/_gen/assets/scss/css/oldnew-mashup.scss_edfe92e93c605395fc6c399f82aa3ba0.content
+++ b/resources/_gen/assets/scss/css/oldnew-mashup.scss_edfe92e93c605395fc6c399f82aa3ba0.content
@@ -1331,6 +1331,10 @@ table {
     flex-flow: row nowrap;
     justify-content: stretch;
     margin-left: 2em; }
+    .menubar-site-menu .menu-parent .menu-item .menu-parent:nth-child(1n+2) {
+      display: none; }
+      .menubar-site-menu .menu-parent .menu-item .menu-parent:nth-child(1n+2) .menu-item {
+        display: none; }
     .menubar-site-menu > .menubar-site-menu-list {
       align-content: space-around;
       align-items: center;


### PR DESCRIPTION
Formatting goes astray after the second level (two levels below the
menu bar), so don't display anything below it in the menu bar — that's
what the sidebar section navbar is for.

Signed-off-by: Daniel F. Dickinson <cshored@thecshore.com>