### PR TITLE
Fix display of site licenses

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -16,7 +16,7 @@ min_version = "0.57.2"
 
 [params]
   siteid = 'OldNew Mashup'
-  license = 'CC-BY-4.0'
+  licenses = ['CC-BY-4.0']
   copyright = '© 2018-2019 Daniel F. Dickinson'
   GitHubRepo = 'cshoredaniel/new-oldnew-mashup'
   rssfeedlink = true

--- a/exampleSite/content/docs/reference-guide.md
+++ b/exampleSite/content/docs/reference-guide.md
@@ -67,7 +67,7 @@ theme = 'new-oldnew-mashup'
 
 [params]
   siteid = 'Site Title/ID'
-  license = 'CC-BY-4.0'
+  licenses = ['CC-BY-4.0']
   copyright = '© 2018 Daniel F. Dickinson'
   default_background_color = '#aba'
   default_text_color = '#454'
@@ -82,7 +82,7 @@ and so on.
 | Param                               | Description                    |
 |-------------------------------------|--------------------------------|
 | siteid                              | Appears in the site badge as the site identifier |
-| license                             | License for the site as a whole (needs the matching taxonomy to exist for the colophon link) |
+| licenses                             | Licenses for the site as a whole (needs the matching taxonomy to exist for the colophon link); should be a list |
 | copyright                           | The copyright year and holder name |
 | site_badge_graphic                  | path to graphic for the site badge |
 | site_badge_graphic_alt_text         | ALT text for graphic for the site badge |

--- a/layouts/partials/footer/colophon/license/site.html
+++ b/layouts/partials/footer/colophon/license/site.html
@@ -1,6 +1,6 @@
-{{ $licenses := .Param "licenses" }}
+{{ $licenses := $.Site.Param "licenses" }}
 {{ if eq $licenses nil }}
-  {{ $licenses = slice "CC-BY-4.0" }}
+  {{ $licenses = slice "Proprietary" }}
 {{ end }}
 <ul class="license-list">
   <!-- Copyright 2018-2019 Daniel F. Dickinson,


### PR DESCRIPTION
1) Default to Proprietary — it's safer to be restrictive by default
2) Use the actual site licenses and not the page licenses (or default of
Proprietary if no site licenses are found).

Signed-off-by: Daniel F. Dickinson <cshored@thecshore.com>