### PR TITLE
Fix no title in frontmatter of regular section

### DIFF
--- a/layouts/partials/generic-helpers/section/listitem.html
+++ b/layouts/partials/generic-helpers/section/listitem.html
@@ -2,7 +2,7 @@
      Released under the Creative Commons BY (Attribution) 4.0 License -->
 {{ $curCtx := . }}
 {{ with .itemPage }}
-  <li class="page-list-item"><a href="{{ .Permalink }}">{{ .Title }}</a>{{ if $curCtx.taxonomyPage }}{{ if $curCtx.taxonomyPage.Count }} &mdash; {{ $curCtx.taxonomyPage.Count }}{{ end }}{{ end }}
+  <li class="page-list-item"><a href="{{ .Permalink }}">{{ if .Title }}{{ .Title }}{{ else if .File }}{{ if .File.BaseTranslationName }}{{ .File.BaseTranslationName }}{{ end }}{{ end }}</a>{{ if $curCtx.taxonomyPage }}{{ if $curCtx.taxonomyPage.Count }} &mdash; {{ $curCtx.taxonomyPage.Count }}{{ end }}{{ end }}
   {{ if (and .Data.Pages (not $curCtx.taxonomyPage) ) }}
     <ol>
     {{ partial "generic-helpers/section/nesting" . }}


### PR DESCRIPTION
In regular (non-time-based) sections, missing titles resulted
in blank entries in section toc.  We fix that by make the title
base filename if there is not title.

Signed-off-by: Daniel F. Dickinson <cshored@thecshore.com>