### PR TITLE
Fix reference guide table definition

### DIFF
--- a/exampleSite/content/docs/reference-guide.md
+++ b/exampleSite/content/docs/reference-guide.md
@@ -97,7 +97,8 @@ the parameter becomes the site-wide default — or as a Page param (which
 applies only to a individual page).
 
 | Param                               | Description                    |
-|-------------------------------------|--------------------------------| nobaseurl                           | Don't use BaseURL even if one is set in the config |
+|-------------------------------------|--------------------------------|
+| nobaseurl                           | Don't use BaseURL even if one is set in the config |
 | nofooterlinks                       | Don't display the footer links section |
 | nocontact                           | Don't display contact footer link |
 | nositemap                           | Don't display sitemap footer link |


### PR DESCRIPTION
Table failed to be a table due to missing character.

Signed-off-by: Daniel F. Dickinson <cshored@thecshore.com>