### PR TITLE
Update README with stable branch Travis status

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Version 0.9.1
 
-[![Travis CI results](https://travis-ci.org/cshoredaniel/new-oldnew-mashup.svg?branch=master)](https://travis-ci.org/cshoredaniel/new-oldnew-mashup?branch=master)
+[![Travis CI results](https://travis-ci.org/cshoredaniel/new-oldnew-mashup.svg?branch=stable-0.9)](https://travis-ci.org/cshoredaniel/new-oldnew-mashup?branch=stable-0.9)
 
 ## Overview
 


### PR DESCRIPTION
Update the Travis status badge to point to stable branch instead of master.

Signed-off-by: Daniel F. Dickinson <cshored@thecshore.com>