### PR TITLE
Fix circular expansion list shortcode

### DIFF
--- a/layouts/shortcodes/summary-list-expansion.html
+++ b/layouts/shortcodes/summary-list-expansion.html
@@ -6,16 +6,19 @@
 {{ end }}
 {{ $curPage := .Page }}
 {{ $startNodes := .Scratch.Get "aNil" }}
+{{ $nodes := .Scratch.Get "aNil" }}
 {{ $menuType := (printf "%s-%s" "sidebar" $pageType) }}
 {{ if eq $pageType "recent" }}
   {{ $startNodes = (where .Site.RegularPages ".Params.date" "!=" nil ) }}
 {{ else }}
   {{ $startNodes = (where (where .Site.RegularPages "Type" $pageType) ".Params.date" "!=" nil) }}
 {{ end }}
-{{ $nodes := ( partial "generic-site-menu/nodes-included" (dict "nodes" $startNodes "menu_node" . "menu_type" $menuType "exclude_self" true ) ) }}
+{{ if $startNodes }}
+  {{ $nodes = ( partial "generic-site-menu/nodes-included" (dict "nodes" $startNodes "menu_node" . "menu_type" $menuType "exclude_self" true ) ) }}
+{{ end }}
 {{ if $nodes }}
   {{ range first $itemCount $nodes.ByDate.Reverse }}
-    {{ if ne . $curPage }}
+    {{ if and (ne .Page $curPage) (not (in .RawContent "summary-list-expansion") ) }}
   <section class="recent-changes">
     <header class="recent-changes-header">
       <h3><a href='{{ .Permalink }}'>{{ if .Title }}{{ .Title }}{{ else }}{{ .File.TranslationBaseName | title }}{{ end }}</a></h3>


### PR DESCRIPTION
The .Summary was executing the shortcode from within the shortcode.  We
now detect when we are inside a summary-expansion-list and do not
display those in the expansion-list.

Signed-off-by: Daniel F. Dickinson <cshored@thecshore.com>