### PR TITLE
Omit recent-xxx as sidebar recent items

### DIFF
--- a/exampleSite/content/siteentry/recent-changes.md
+++ b/exampleSite/content/siteentry/recent-changes.md
@@ -16,6 +16,7 @@ tags:
   - recent
 weight: 30
 norbar: true
+not_in_lists: [sidebar-recent,sidebar-events,sidebar-news]
 ---
 
 # Recent Changes

--- a/exampleSite/content/siteentry/recent-events.md
+++ b/exampleSite/content/siteentry/recent-events.md
@@ -16,6 +16,7 @@ tags:
   - recent
 weight: 50
 norbar: true
+not_in_lists: [sidebar-recent,sidebar-events,sidebar-news]
 ---
 
 # Recently Published Events

--- a/exampleSite/content/siteentry/recent-news.md
+++ b/exampleSite/content/siteentry/recent-news.md
@@ -16,6 +16,7 @@ tags:
   - recent
 weight: 40
 norbar: true
+not_in_lists: [sidebar-recent,sidebar-events,sidebar-news]
 ---
 
 # Recent News


### PR DESCRIPTION
Recent-xxx pages as sidebar items or as recent-xxx items is rather
spammy, so avoid it.

Signed-off-by: Daniel F. Dickinson <cshored@thecshore.com>