### PR TITLE
Fix per-page title element

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -4,7 +4,7 @@
      Released under the Create Commons BY (Attribution) 4.0 License -->
   <head>
     <title>{{ block "title" . }}
-      {{ .Site.Title }}
+      {{ if .Title }}{{ .Title }}{{ else if .Name }}{{ .Name }}{{ else }}{{ .Site.Title }}{{ end }}
     {{ end }}</title>
     {{ block "head" . }}
        {{ partial "head/theme" . }}

--- a/layouts/_default/section.html
+++ b/layouts/_default/section.html
@@ -1,5 +1,5 @@
 {{ define "title" }}
-  {{ if .Title }}{{ .Title }}{{ end }}
+  {{ if .Title }}{{ .Title }}{{ else if .Name }}{{ .Name }}{{ else }}{{ .Site.Title }}{{ end }}
 {{ end }}
 {{ define "bodytag" }}
   <body>


### PR DESCRIPTION
Every page had the site title instead of per-page title.  Fix that.

Signed-off-by: Daniel F. Dickinson <cshored@thecshore.com>