### PR TITLE
Fix recent-* for pages with no content

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -35,7 +35,7 @@ min_version = "0.65.3"
 
 [frontmatter]
   lastmod = ["lastmod",":git","date","publishDate"]
-  date = ["publishDate","date",":git","lastmod"]
+  date = ["publishDate","date"]
 
 [privacy]
   [privacy.disqus]

--- a/layouts/partials/generic-site-menu/nodes-included.html
+++ b/layouts/partials/generic-site-menu/nodes-included.html
@@ -22,6 +22,11 @@
            {{ $includeNode = false }}
          {{ end }}
       {{ end }}
+      {{ if and (and $ctx.minSummaryLen $includeNode) (not (in .RawContent "summary-list-expansion" )) }}
+        {{ if and (lt (len .Summary) (int $ctx.minSummaryLen)) (not .Params.description) }}
+          {{ $includeNode = false }}
+        {{ end }}
+      {{ end }}
       {{ if $includeNode }}
         {{ if not $haveNode }}
           {{ $scratch.Set "nodes_included" ( slice . ) }}

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -2,7 +2,7 @@
 {{ if not (.Param "norbar") }}
 <div class="sidebar">
   {{ $newsPages := (where (where .Site.Pages "Type" "news") ".Params.date" "!=" nil) }}
-  {{ $newsNodes := ( partial "generic-site-menu/nodes-included" (dict "nodes" $newsPages "menu_node" . "menu_type" "sidebar-news" "exclude_self" true ) ) }}
+  {{ $newsNodes := ( partial "generic-site-menu/nodes-included" (dict "nodes" $newsPages "menu_node" . "menu_type" "sidebar-news" "exclude_self" true "minSummaryLen" 10) ) }}
   {{ if $newsNodes }}
     <section aria-labelledby="sidebar-news-title" id="sidebar-news" class="page-news sidebar-box">
       <h2 id="sidebar-news-title" class="sidebar-title">{{ if .Param "recent_news" }}{{ if .Site.GetPage ( .Param "recent_news") }}<a href="{{ .Param "recent_news" }}">{{ end }}{{ end }}News{{ if .Param "recent_news" }}{{ if .Site.GetPage (.Param "recent_news") }}</a>{{ end }}{{ end }}</h2>
@@ -12,7 +12,7 @@
      </section>
   {{ end }}
   {{ $eventPages := (where (where .Site.Pages "Type" "events") ".Params.date" "!=" nil) }}
-  {{ $eventNodes := ( partial "generic-site-menu/nodes-included" (dict "nodes" $eventPages "menu_node" . "menu_type" "sidebar-events"  "exclude_self" true ) ) }}
+  {{ $eventNodes := ( partial "generic-site-menu/nodes-included" (dict "nodes" $eventPages "menu_node" . "menu_type" "sidebar-events"  "exclude_self" true "minSummaryLen" 10) ) }}
   {{ if $eventNodes }}
     <section aria-labelledby="sidebar-events-title" id="sidebar-events" class="sidebar-page-events sidebar-box">
       <h2 id="sidebar-events-title" class="sidebar-title">{{ if .Param "recent_events" }}{{ if .Site.GetPage ( .Param "recent_events") }}<a href="{{ .Param "recent_events" }}">{{ end }}{{ end }}Events{{ if .Param "recent_events" }}{{ if .Site.GetPage ( .Param "recent_events" ) }}</a>{{ end }}{{ end }}</h2>
@@ -22,7 +22,7 @@
      </section>
   {{ end }}
   {{ $startNodes := (where (where .Site.Pages ".Params.date" "!=" nil)  "Type" "!=" "news" ) }}
-  {{ $nodes := ( partial "generic-site-menu/nodes-included" (dict "nodes" $startNodes "menu_node" . "menu_type" "sidebar-recent"  "exclude_self" true ) ) }}
+  {{ $nodes := ( partial "generic-site-menu/nodes-included" (dict "nodes" $startNodes "menu_node" . "menu_type" "sidebar-recent"  "exclude_self" true "minSummaryLen" 10) ) }}
   {{ if $nodes }}
   <div class="sidebar-recent-additions-wrapper">
     <section aria-labelledby="sidebar-recent-additions" class="sidebar-recent-changes sidebar-box">
@@ -34,7 +34,7 @@
   </div>
   {{ end }}
   {{ $startNodes = (where (where .Site.Pages ".Params.lastmod" "!=" nil ) "Type" "!=" "news" ) }}
-  {{ $nodes := ( partial "generic-site-menu/nodes-included" (dict "nodes" $startNodes "menu_node" . "menu_type" "sidebar-recent"  "exclude_self" true ) ) }}
+  {{ $nodes := ( partial "generic-site-menu/nodes-included" (dict "nodes" $startNodes "menu_node" . "menu_type" "sidebar-recent"  "exclude_self" true "minSummaryLen" 10) ) }}
   {{ if $nodes }}
       <section aria-labelledby="sidebar-recent-changes" class="sidebar-recent-changes sidebar-box">
         <h2 id="sidebar-recent-changes" class="sidebar-title">{{ if .Param "recent_changes" }}{{ if .Site.GetPage ( .Param "recent_changes") }}<a href="{{ .Param "recent_changes" }}">{{ end }}{{ end }}Recent Changes{{ if .Param "recent_changes" }}{{ if .Site.GetPage (.Param "recent_changes") }}</a>{{ end }}{{ end }}</h2>

--- a/layouts/shortcodes/summary-list-expansion.html
+++ b/layouts/shortcodes/summary-list-expansion.html
@@ -12,11 +12,10 @@
 {{ else if (ne $pageType "recent") }}
   {{ $startNodes = (where (where .Site.RegularPages "Type" $pageType) ".Params.date" "!=" nil) }}
 {{ end }}
-{{ $nodes := ( partial "generic-site-menu/nodes-included" (dict "nodes" $startNodes "menu_node" . "menu_type" $menuType "exclude_self" true ) ) }}
+{{ $nodes := ( partial "generic-site-menu/nodes-included" (dict "nodes" $startNodes "menu_node" . "menu_type" $menuType "exclude_self" true "minSummaryLen" 10 ) ) }}
 {{ if and (eq $pageType "recent-changes") $nodes }}
   {{ range first $itemCount $nodes.ByLastmod.Reverse }}
     {{ if and (ne .Page $curPage) (not (in .RawContent "summary-list-expansion") ) }}
-      {{ if or (ge (len .Summary) 10) .Page.Params.description }}
   <section class="recent-changes">
     <header class="recent-changes-header">
       <h3><a href='{{ .Permalink }}'>{{ if .Title }}{{ .Title }}{{ else }}{{ .File.TranslationBaseName | title }}{{ end }}</a></h3>
@@ -30,13 +29,11 @@
       {{ end }}
     </footer>
   </section>
-      {{ end }}
     {{ end }}
   {{ end }}
-{{ else if $nodes }}
+{{ else if (and $nodes (ne $pageType "recent-changes")) }}
   {{ range first $itemCount $nodes.ByDate.Reverse }}
     {{ if and (ne .Page $curPage) (not (in .RawContent "summary-list-expansion") ) }}
-      {{ if or (ge (len .Summary) 10) .Page.Params.description }}
   <section class="recent-changes">
     <header class="recent-changes-header">
       <h3><a href='{{ .Permalink }}'>{{ if .Title }}{{ .Title }}{{ else }}{{ .File.TranslationBaseName | title }}{{ end }}</a></h3>
@@ -50,7 +47,6 @@
       {{ end }}
     </footer>
    </section>
-      {{ end }}
     {{ end }}
   {{ end }}
 {{ end }}


### PR DESCRIPTION
Move the logic for detecting no content so that we actually
get the requested number of nodes (if available).

Signed-off-by: Daniel F. Dickinson <cshored@thecshore.com>