### PR TITLE
Fix licenses pages

### DIFF
--- a/layouts/_default/taxonomy.html
+++ b/layouts/_default/taxonomy.html
@@ -23,7 +23,7 @@
   {{ end }}
   {{ if eq .Data.Singular "license" }}
     <h2>License Text</h2>
-      <pre class="license-block chroma">{{ $license = .Data.Term }}{{ if $license }}{{ $licenseFile := resources.Get (print "licenses/" $license) }}{{ with $licenseFile }}{{ .Content }}{{ else }}Missing{{ end }}{{ else }}Missing Term{{ end }}</pre>
+      <pre class="license-block chroma">{{ $license = .Data.Term }}{{ if $license }}{{ $licenseFile := resources.GetMatch (print "licenses/" $license) }}{{ with $licenseFile }}{{ .Content }}{{ else }}Missing{{ end }}{{ else }}Missing Term{{ end }}</pre>
   {{ else }}
     {{ .Content }}
   {{ end }}
@@ -31,7 +31,7 @@
   </section>
   {{ if eq .Data.Singular "license" }}
   <section class="license-pages-section">
-    <h2>Pages with {{ $license }} license</h2>
+    <h2>Pages with {{ $license | title }} license</h2>
   {{ else }}
   <section aria-labelledby="taxonomy-contents-heading" class="taxonomy-list">
     <h2 id="taxonomy-contents-heading" class="taxonomy-contents-heading">{{ if .Data.Terms }}{{ .Data.Singular | singularize | title }} List{{ else}}{{ .Title | singularize | title }} Pages{{ end }}</h2>

--- a/layouts/partials/generic-helpers/section/listitem.html
+++ b/layouts/partials/generic-helpers/section/listitem.html
@@ -6,7 +6,7 @@
     <a class="page-list-link" href="{{ .Permalink }}"><span class="page-list-entry">{{ if .Title }}{{ .Title }}{{ else if .File }}{{ if .File.TranslationBaseName }}{{ .File.TranslationBaseName | title }}{{ end }}{{ end }}</span></a>
     {{- if $curCtx.taxonomyPage -}}
       {{- if $curCtx.taxonomyPage.Count -}}<span class="taxonomy-term-separator"> &mdash; </span><span class="taxonomy-term-count">{{- $curCtx.taxonomyPage.Count -}}</span>{{- end -}}{{- end -}}
-  {{- if (and .Data.Pages (not $curCtx.taxonomyPage) ) -}}
+  {{- if (and (and .Data.Pages (not $curCtx.taxonomyPage) (ne $curCtx.menu_type "taxonomy-term" ) ) ) -}}
     <ol class="page-list-parent">
     {{ partial "generic-helpers/section/nesting" . }}
     </ol>

--- a/layouts/partials/generic-helpers/section/nesting.html
+++ b/layouts/partials/generic-helpers/section/nesting.html
@@ -14,7 +14,7 @@
 {{- else if .Data.Singular -}}
   {{- $nodes = ( partial "generic-site-menu/nodes-included" (dict "nodes" .Data.Pages "menu_node" . "menu_type" "taxonomy-term" ) ) -}}
   {{- range $nodes -}}
-    {{ partial "generic-helpers/section/listitem" (dict "itemPage" .Page "parentPage" $curCtx ) }}
+    {{ partial "generic-helpers/section/listitem" (dict "itemPage" .Page "parentPage" $curCtx "menu_type" "taxonomy-term" ) }}
   {{- end -}}
 {{- else -}}
   {{- range $nodes -}}


### PR DESCRIPTION
Licenses pages were not necessarily finding the license assets
due to case sensitivity / unexpected case issues.  In addition
the listing of pages for a particular license was using entirely
the wrong logic.

Both of these have been fixed.

Signed-off-by: Daniel F. Dickinson <cshored@thecshore.com>